### PR TITLE
Improve main page character win-rate readability UI

### DIFF
--- a/css/renewal.css
+++ b/css/renewal.css
@@ -1681,6 +1681,83 @@ div:has(> .beforeSeason) {
 .charWinRate {
     position: relative;
 }
+.season2025U #charRate table tbody td {
+    vertical-align: middle;
+}
+.season2025U #charRate .rankBadge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    background: #f1f3f5;
+    font-weight: 700;
+    color: #495057;
+}
+.season2025U #charRate .charIdentity {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.season2025U #charRate .charIdentity img {
+    width: 38px;
+    height: 38px;
+    border-radius: 8px;
+    border: 1px solid #dee2e6;
+}
+.season2025U #charRate .winrateCell {
+    min-width: 150px;
+}
+.season2025U #charRate .winrateHeader {
+    line-height: 1;
+    margin-bottom: 6px;
+}
+.season2025U #charRate .winrateValue {
+    font-size: 17px;
+}
+.season2025U #charRate .winrateValue.high {
+    color: #228be6;
+}
+.season2025U #charRate .winrateValue.mid {
+    color: #2b8a3e;
+}
+.season2025U #charRate .winrateValue.low {
+    color: #e03131;
+}
+.season2025U #charRate .winrateBar {
+    width: 100%;
+    height: 8px;
+    background: #e9ecef;
+    border-radius: 999px;
+    overflow: hidden;
+}
+.season2025U #charRate .winrateBar > span {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, #74c0fc, #228be6);
+}
+.season2025U #charRate .winrateRecord {
+    margin-top: 6px;
+    display: flex;
+    gap: 6px;
+}
+.season2025U #charRate .winChip,
+.season2025U #charRate .loseChip {
+    display: inline-block;
+    border-radius: 999px;
+    font-size: 11px;
+    padding: 2px 7px;
+    font-weight: 700;
+}
+.season2025U #charRate .winChip {
+    color: #1c7ed6;
+    background: #e7f5ff;
+}
+.season2025U #charRate .loseChip {
+    color: #e03131;
+    background: #fff5f5;
+}
 .charWinRate > .charSearch {
     position: absolute;
     right: 0;

--- a/views/pc/stats.ejs
+++ b/views/pc/stats.ejs
@@ -109,17 +109,35 @@
             } else {
                 for (let idx in list) {
                     const { char_name, total_matches: total, win_count, lose_count, rate } = list[idx];
+                    const rateNumber = Number(rate) || 0;
+                    const rateToneClass = rateNumber >= 55 ? "high" : rateNumber >= 48 ? "mid" : "low";
                     let number = ((sortBy === "rate" && !isRateDesc) || (sortBy === "totalMatches" && !isTotalMatchesDesc))
                         ? list.length - Number(idx)
                         : Number(idx) + 1;
 
                     let tr = `<tr>
-                                <td>${number}</td>
-                                <td><img data-item='${char_name}' src='https://img-api.neople.co.kr/cy/characters/${charMap.get(char_name)}' alt="${char_name}"></td>
+                                <td><span class="rankBadge">${number}</span></td>
+                                <td>
+                                    <div class="charIdentity">
+                                        <img data-item='${char_name}' src='https://img-api.neople.co.kr/cy/characters/${charMap.get(char_name)}' alt="${char_name}">
+                                        <strong>${char_name}</strong>
+                                    </div>
+                                </td>
                                 <td>${total.toLocaleString()}</td>
                                 <td>${win_count.toLocaleString()}</td>
                                 <td>${lose_count.toLocaleString()}</td>
-                                <td>${rate}%</td>
+                                <td>
+                                    <div class="winrateCell">
+                                        <div class="winrateHeader">
+                                            <strong class="winrateValue ${rateToneClass}">${rateNumber}%</strong>
+                                        </div>
+                                        <div class="winrateBar"><span style="width:${Math.max(0, Math.min(rateNumber, 100))}%"></span></div>
+                                        <div class="winrateRecord">
+                                            <span class="winChip">W ${win_count.toLocaleString()}</span>
+                                            <span class="loseChip">L ${lose_count.toLocaleString()}</span>
+                                        </div>
+                                    </div>
+                                </td>
                               </tr>`;
                     tbody.append(tr);
                 }


### PR DESCRIPTION
### Motivation
- The character win-rate table on the main stats page was text-heavy and hard to scan at a glance.  
- Make per-character performance easier to compare visually by surfacing rank, avatar, name, color-coded percentage, and a progress bar.  

### Description
- Updated `views/pc/stats.ejs` (`drawCharFunc`) to render each row with a rank badge, combined avatar + name block, and a compact `winrateCell` containing a color-coded percentage, a horizontal progress bar, and W/L chips.  
- Added small logic to compute numeric rate and a tone class (`rateNumber` and `rateToneClass` with thresholds `>=55` = `high`, `>=48` = `mid`, else `low`) to drive color variants.  
- Added styling in `css/renewal.css` scoped under the season stats (`.season2025U #charRate`) for badges, avatar layout, progress bar, and W/L chips to ensure consistent visual appearance.  
- Existing sorting and search behaviors (`toggleCharRate`, `toggleTotalMatches`, `searchChar`) are preserved and work with the new row markup.  

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed (`3` test suites, `14` tests passed).  
- No automated visual tests were added; manual verification is recommended in a browser to confirm layout and responsive behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0ea89e838832799789798f7414f86)